### PR TITLE
feat(sentinel): implement standardized work item interface (Epic #4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -428,3 +428,12 @@ test-results-pester.xml
 
 # MCP memory knowledge graph (cached via GH Actions, not committed)
 .memory/
+
+# Python virtual environments
+.venv/
+venv/
+ENV/
+env/
+*.egg-info/
+dist/
+build/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,119 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "sentinel"
+version = "0.1.0"
+description = "Workflow Orchestration Queue System - A unified work item interface for provider-agnostic queue operations"
+readme = "README.md"
+license = "MIT"
+requires-python = ">=3.12"
+authors = [
+    { name = "Sentinel Team", email = "sentinel@example.com" }
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+dependencies = [
+    "pydantic>=2.0.0,<3.0.0",
+    "requests>=2.28.0,<3.0.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-cov>=4.0.0",
+    "pytest-asyncio>=0.23.0",
+    "ruff>=0.4.0",
+    "mypy>=1.10.0",
+    "types-requests>=2.31.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/intel-agency/workflow-orchestration-queue-zulu48"
+Documentation = "https://github.com/intel-agency/workflow-orchestration-queue-zulu48#readme"
+Repository = "https://github.com/intel-agency/workflow-orchestration-queue-zulu48"
+Issues = "https://github.com/intel-agency/workflow-orchestration-queue-zulu48/issues"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/sentinel"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]
+addopts = [
+    "-v",
+    "--tb=short",
+    "--strict-markers",
+    "--cov=sentinel",
+    "--cov-report=term-missing",
+    "--cov-report=xml:coverage.xml",
+    "--cov-fail-under=80",
+]
+markers = [
+    "unit: Unit tests",
+    "integration: Integration tests",
+    "slow: Slow running tests",
+]
+
+[tool.coverage.run]
+source = ["src/sentinel"]
+branch = true
+omit = [
+    "*/tests/*",
+    "*/__pycache__/*",
+]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "def __repr__",
+    "raise NotImplementedError",
+    "if TYPE_CHECKING:",
+    "if __name__ == .__main__.:",
+    "@abstractmethod",
+]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 100
+src = ["src", "tests"]
+
+[tool.ruff.lint]
+select = [
+    "E",   # pycodestyle errors
+    "W",   # pycodestyle warnings
+    "F",   # Pyflakes
+    "I",   # isort
+    "B",   # flake8-bugbear
+    "C4",  # flake8-comprehensions
+    "UP",  # pyupgrade
+    "ARG", # flake8-unused-arguments
+    "SIM", # flake8-simplify
+]
+ignore = [
+    "E501",  # line too long (handled by formatter)
+    "B008",  # do not perform function calls in argument defaults
+]
+
+[tool.ruff.lint.isort]
+known-first-party = ["sentinel"]
+
+[tool.mypy]
+python_version = "3.12"
+strict = true
+warn_return_any = true
+warn_unused_ignores = true
+disallow_untyped_defs = true
+plugins = ["pydantic.mypy"]
+
+[[tool.mypy.overrides]]
+module = "tests.*"
+disallow_untyped_defs = false

--- a/src/sentinel/__init__.py
+++ b/src/sentinel/__init__.py
@@ -1,0 +1,7 @@
+"""
+Sentinel - Workflow Orchestration Queue System
+
+A unified work item interface for provider-agnostic queue operations.
+"""
+
+__version__ = "0.1.0"

--- a/src/sentinel/interfaces/__init__.py
+++ b/src/sentinel/interfaces/__init__.py
@@ -1,0 +1,5 @@
+"""Sentinel interfaces package."""
+
+from .work_queue import IWorkQueue
+
+__all__ = ["IWorkQueue"]

--- a/src/sentinel/interfaces/work_queue.py
+++ b/src/sentinel/interfaces/work_queue.py
@@ -1,0 +1,115 @@
+"""Abstract base class for work queue interfaces.
+
+This module defines the IWorkQueue abstract base class that specifies
+the interface for provider-agnostic queue operations.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Protocol
+
+from ..models.work_item import WorkItem, WorkItemStatus
+
+
+class IWorkQueue(ABC):
+    """Abstract base class defining the interface for work queue operations.
+
+    This interface provides a provider-agnostic way to interact with different
+    queue backends (GitHub Issues, Linear, Jira, etc.). Concrete implementations
+    should map provider-specific APIs to these interface methods.
+
+    Methods:
+        fetch_queued_items: Retrieve all work items that are ready for processing.
+        update_item_status: Update the status of a specific work item.
+
+    Example:
+        ```python
+        class GitHubIssueQueue(IWorkQueue):
+            def __init__(self, repo: str, token: str):
+                self.repo = repo
+                self.token = token
+
+            def fetch_queued_items(self) -> list[WorkItem]:
+                # Implementation using GitHub REST API
+                ...
+
+            def update_item_status(self, item: WorkItem, status: WorkItemStatus) -> WorkItem:
+                # Implementation using GitHub REST API
+                ...
+        ```
+    """
+
+    @abstractmethod
+    def fetch_queued_items(self) -> list[WorkItem]:
+        """Fetch all work items that are queued and ready for processing.
+
+        This method should retrieve work items from the underlying queue provider
+        that are in a state ready to be processed (e.g., GitHub issues with
+        specific labels like 'orchestration:ready').
+
+        Returns:
+            A list of WorkItem objects representing the queued work items.
+            Returns an empty list if no items are queued.
+
+        Raises:
+            QueueConnectionError: If unable to connect to the queue provider.
+            QueueAuthenticationError: If authentication with the provider fails.
+
+        Example:
+            ```python
+            queue = GitHubIssueQueue(repo="owner/repo", token="ghp_xxx")
+            items = queue.fetch_queued_items()
+            for item in items:
+                print(f"Processing: {item.id} - {item.context_body[:50]}")
+            ```
+        """
+        ...
+
+    @abstractmethod
+    def update_item_status(self, item: WorkItem, status: WorkItemStatus) -> WorkItem:
+        """Update the status of a work item in the queue.
+
+        This method should update the work item's status in the underlying
+        provider (e.g., by changing GitHub issue labels) and return the
+        updated work item.
+
+        Args:
+            item: The work item to update.
+            status: The new status to set for the work item.
+
+        Returns:
+            The updated WorkItem with the new status reflected.
+
+        Raises:
+            ItemNotFoundError: If the work item cannot be found in the queue.
+            QueueConnectionError: If unable to connect to the queue provider.
+            QueueAuthenticationError: If authentication with the provider fails.
+
+        Example:
+            ```python
+            queue = GitHubIssueQueue(repo="owner/repo", token="ghp_xxx")
+            item = queue.fetch_queued_items()[0]
+            updated = queue.update_item_status(item, WorkItemStatus.IN_PROGRESS)
+            print(f"Status updated to: {updated.status}")
+            ```
+        """
+        ...
+
+
+class IWorkQueueProtocol(Protocol):
+    """Protocol version of IWorkQueue for structural subtyping.
+
+    This protocol allows any class that implements the required methods
+    to be treated as an IWorkQueue, even if it doesn't explicitly inherit
+    from IWorkQueue.
+
+    Use IWorkQueue (ABC) for explicit inheritance and IWorkQueueProtocol
+    for structural type checking.
+    """
+
+    def fetch_queued_items(self) -> list[WorkItem]:
+        """Fetch all work items that are queued and ready for processing."""
+        ...
+
+    def update_item_status(self, item: WorkItem, status: WorkItemStatus) -> WorkItem:
+        """Update the status of a work item in the queue."""
+        ...

--- a/src/sentinel/models/__init__.py
+++ b/src/sentinel/models/__init__.py
@@ -1,0 +1,5 @@
+"""Sentinel models package."""
+
+from .work_item import TaskType, WorkItem, WorkItemStatus
+
+__all__ = ["WorkItem", "TaskType", "WorkItemStatus"]

--- a/src/sentinel/models/work_item.py
+++ b/src/sentinel/models/work_item.py
@@ -1,0 +1,132 @@
+"""Work Item model for Sentinel queue system.
+
+This module defines the WorkItem Pydantic model and related enums for
+representing standardized work items across different queue providers.
+"""
+
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class TaskType(str, Enum):
+    """Enumeration of task types for work items."""
+
+    PLAN = "PLAN"
+    """Planning task - analysis, design, or documentation work."""
+
+    IMPLEMENT = "IMPLEMENT"
+    """Implementation task - coding, configuration, or deployment work."""
+
+
+class WorkItemStatus(str, Enum):
+    """Enumeration of work item statuses mapping to GitHub labels.
+
+    These statuses correspond to common workflow states and can be mapped
+    to provider-specific status representations (e.g., GitHub labels).
+    """
+
+    QUEUED = "QUEUED"
+    """Item is queued and waiting to be processed."""
+
+    IN_PROGRESS = "IN_PROGRESS"
+    """Item is currently being worked on."""
+
+    BLOCKED = "BLOCKED"
+    """Item is blocked and cannot proceed."""
+
+    REVIEW = "REVIEW"
+    """Item is under review."""
+
+    COMPLETED = "COMPLETED"
+    """Item has been completed successfully."""
+
+    CANCELLED = "CANCELLED"
+    """Item has been cancelled and will not be processed."""
+
+
+class WorkItem(BaseModel):
+    """Unified Pydantic model representing a standardized work item.
+
+    This model provides a provider-agnostic representation of work items
+    that can be used across different queue providers (GitHub, Linear, Jira, etc.).
+
+    Attributes:
+        id: Unique identifier for the work item (string or integer).
+        source_url: URL of the original source (e.g., GitHub issue URL).
+        context_body: The main content/context of the work item.
+        target_repo_slug: Target repository in format 'owner/repo'.
+        task_type: Type of task (PLAN or IMPLEMENT).
+        status: Current status of the work item.
+        metadata: Flexible dictionary for provider-specific data (e.g., GitHub node_id).
+
+    Example:
+        ```python
+        work_item = WorkItem(
+            id="12345",
+            source_url="https://github.com/owner/repo/issues/42",
+            context_body="Implement user authentication",
+            target_repo_slug="owner/repo",
+            task_type=TaskType.IMPLEMENT,
+            status=WorkItemStatus.QUEUED,
+            metadata={"issue_node_id": "I_kwDOABC123"}
+        )
+        ```
+    """
+
+    id: str | int = Field(
+        ...,
+        description="Unique identifier for the work item",
+        examples=["12345", "GH-42", 12345],
+    )
+    source_url: str = Field(
+        ...,
+        description="URL of the original source (e.g., GitHub issue URL)",
+        examples=["https://github.com/owner/repo/issues/42"],
+    )
+    context_body: str = Field(
+        ...,
+        description="The main content/context of the work item",
+        examples=["Implement user authentication with OAuth2"],
+    )
+    target_repo_slug: str = Field(
+        ...,
+        description="Target repository in format 'owner/repo'",
+        pattern=r"^[^/]+/[^/]+$",
+        examples=["owner/repo"],
+    )
+    task_type: TaskType = Field(
+        ...,
+        description="Type of task (PLAN or IMPLEMENT)",
+    )
+    status: WorkItemStatus = Field(
+        default=WorkItemStatus.QUEUED,
+        description="Current status of the work item",
+    )
+    metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Flexible dictionary for provider-specific data (e.g., GitHub node_id)",
+        examples=[
+            {"issue_node_id": "I_kwDOABC123", "labels": ["bug", "priority-high"]}
+        ],
+    )
+
+    model_config = {
+        "frozen": False,
+        "extra": "forbid",
+        "use_enum_values": True,
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "id": "42",
+                    "source_url": "https://github.com/owner/repo/issues/42",
+                    "context_body": "Implement user authentication with OAuth2",
+                    "target_repo_slug": "owner/repo",
+                    "task_type": "IMPLEMENT",
+                    "status": "QUEUED",
+                    "metadata": {"issue_node_id": "I_kwDOABC123"},
+                }
+            ]
+        },
+    }

--- a/src/sentinel/providers/__init__.py
+++ b/src/sentinel/providers/__init__.py
@@ -1,0 +1,3 @@
+"""Sentinel providers package."""
+
+__all__ = []

--- a/src/sentinel/providers/github/__init__.py
+++ b/src/sentinel/providers/github/__init__.py
@@ -1,0 +1,5 @@
+"""GitHub provider package."""
+
+from .issue_queue import GitHubIssueQueue
+
+__all__ = ["GitHubIssueQueue"]

--- a/src/sentinel/providers/github/issue_queue.py
+++ b/src/sentinel/providers/github/issue_queue.py
@@ -1,0 +1,342 @@
+"""GitHub Issues implementation of the IWorkQueue interface.
+
+This module provides the GitHubIssueQueue class that implements the
+IWorkQueue interface using the GitHub REST API for issue operations.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, cast
+
+import requests
+
+from ...interfaces.work_queue import IWorkQueue
+from ...models.work_item import TaskType, WorkItem, WorkItemStatus
+
+logger = logging.getLogger(__name__)
+
+
+# Status to GitHub label mappings
+STATUS_TO_LABEL: dict[WorkItemStatus, str] = {
+    WorkItemStatus.QUEUED: "orchestration:ready",
+    WorkItemStatus.IN_PROGRESS: "orchestration:in-progress",
+    WorkItemStatus.BLOCKED: "orchestration:blocked",
+    WorkItemStatus.REVIEW: "orchestration:review",
+    WorkItemStatus.COMPLETED: "orchestration:completed",
+    WorkItemStatus.CANCELLED: "orchestration:cancelled",
+}
+
+# Label to status mappings (reverse)
+LABEL_TO_STATUS: dict[str, WorkItemStatus] = {v: k for k, v in STATUS_TO_LABEL.items()}
+
+# Task type to label mappings
+TASK_TYPE_LABELS: dict[TaskType, str] = {
+    TaskType.PLAN: "task-type:plan",
+    TaskType.IMPLEMENT: "task-type:implement",
+}
+
+
+class GitHubIssueQueue(IWorkQueue):
+    """GitHub Issues implementation of the IWorkQueue interface.
+
+    This class provides a concrete implementation of IWorkQueue that uses
+    the GitHub REST API to manage work items as GitHub Issues.
+
+    Attributes:
+        repo: Repository in 'owner/repo' format.
+        token: GitHub personal access token for authentication.
+        api_base: Base URL for GitHub API (defaults to github.com).
+
+    Example:
+        ```python
+        queue = GitHubIssueQueue(
+            repo="owner/repo",
+            token="ghp_xxxxxxxxxxxx"
+        )
+
+        # Fetch queued items
+        items = queue.fetch_queued_items()
+
+        # Update status
+        updated = queue.update_item_status(items[0], WorkItemStatus.IN_PROGRESS)
+        ```
+    """
+
+    def __init__(
+        self,
+        repo: str,
+        token: str | None = None,
+        api_base: str = "https://api.github.com",
+    ) -> None:
+        """Initialize the GitHub Issue Queue.
+
+        Args:
+            repo: Repository in 'owner/repo' format.
+            token: GitHub personal access token. If not provided, will attempt
+                   to read from GITHUB_TOKEN or GH_TOKEN environment variable.
+            api_base: Base URL for GitHub API. Defaults to github.com API.
+                      Use 'https://api.github.enterprise.com' for GitHub Enterprise.
+
+        Raises:
+            ValueError: If repo is not in 'owner/repo' format or token is not available.
+        """
+        if "/" not in repo or repo.count("/") != 1:
+            raise ValueError(f"Invalid repo format '{repo}'. Expected 'owner/repo'.")
+
+        self.repo = repo
+        self.token = token or os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+        self.api_base = api_base.rstrip("/")
+
+        if not self.token:
+            raise ValueError(
+                "GitHub token is required. Provide it via the 'token' parameter "
+                "or set the GITHUB_TOKEN or GH_TOKEN environment variable."
+            )
+
+    def _get_headers(self) -> dict[str, str]:
+        """Get HTTP headers for GitHub API requests."""
+        return {
+            "Authorization": f"Bearer {self.token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+
+    def _make_request(
+        self,
+        method: str,
+        endpoint: str,
+        **kwargs: Any,
+    ) -> Any:
+        """Make an HTTP request to the GitHub API.
+
+        Args:
+            method: HTTP method (GET, POST, PATCH, etc.).
+            endpoint: API endpoint (without base URL).
+            **kwargs: Additional arguments passed to requests.
+
+        Returns:
+            JSON response (can be dict, list, or other JSON types).
+
+        Raises:
+            GitHubAPIError: If the API request fails.
+        """
+        url = f"{self.api_base}{endpoint}"
+        headers = self._get_headers()
+
+        response = requests.request(
+            method=method,
+            url=url,
+            headers=headers,
+            timeout=30,
+            **kwargs,
+        )
+
+        if response.status_code >= 400:
+            raise GitHubAPIError(
+                f"GitHub API error: {response.status_code} - {response.text}",
+                status_code=response.status_code,
+                response=response,
+            )
+
+        return response.json()
+
+    def _issue_to_work_item(self, issue: dict[str, Any]) -> WorkItem:
+        """Convert a GitHub issue to a WorkItem.
+
+        Args:
+            issue: GitHub issue dictionary from API response.
+
+        Returns:
+            WorkItem representation of the issue.
+        """
+        labels = [label["name"] for label in issue.get("labels", [])]
+
+        # Determine status from labels
+        status = WorkItemStatus.QUEUED
+        for label in labels:
+            if label in LABEL_TO_STATUS:
+                status = LABEL_TO_STATUS[label]
+                break
+
+        # Determine task type from labels
+        task_type = TaskType.IMPLEMENT  # Default
+        for label in labels:
+            if label.startswith("task-type:"):
+                if label == TASK_TYPE_LABELS[TaskType.PLAN]:
+                    task_type = TaskType.PLAN
+                break
+
+        # Extract target repo from issue body or use current repo
+        body = issue.get("body") or ""
+        target_repo = self.repo  # Default to current repo
+
+        # Look for target repo in body (could be extracted from structured content)
+        # For now, we use the current repo as default
+
+        return WorkItem(
+            id=str(issue["number"]),
+            source_url=issue["html_url"],
+            context_body=body,
+            target_repo_slug=target_repo,
+            task_type=task_type,
+            status=status,
+            metadata={
+                "issue_node_id": issue.get("node_id"),
+                "title": issue.get("title"),
+                "labels": labels,
+                "created_at": issue.get("created_at"),
+                "updated_at": issue.get("updated_at"),
+                "user": issue.get("user", {}).get("login"),
+            },
+        )
+
+    def _get_status_label(self, status: WorkItemStatus) -> str:
+        """Get the GitHub label for a given status."""
+        return STATUS_TO_LABEL.get(status, STATUS_TO_LABEL[WorkItemStatus.QUEUED])
+
+    def fetch_queued_items(self) -> list[WorkItem]:
+        """Fetch all work items that are queued and ready for processing.
+
+        Retrieves GitHub issues with the 'orchestration:ready' label that
+        are open and ready to be processed.
+
+        Returns:
+            A list of WorkItem objects representing the queued work items.
+
+        Raises:
+            GitHubAPIError: If the GitHub API request fails.
+        """
+        logger.info(f"Fetching queued items from {self.repo}")
+
+        try:
+            # Fetch issues with orchestration:ready label
+            params = {
+                "state": "open",
+                "labels": STATUS_TO_LABEL[WorkItemStatus.QUEUED],
+                "per_page": 100,
+                "sort": "created",
+                "direction": "asc",
+            }
+
+            issues = cast(
+                list[dict[str, Any]],
+                self._make_request("GET", f"/repos/{self.repo}/issues", params=params),
+            )
+
+            work_items = []
+            for issue in issues:
+                # Skip pull requests (they have pull_request key)
+                if "pull_request" in issue:
+                    continue
+
+                try:
+                    work_item = self._issue_to_work_item(issue)
+                    work_items.append(work_item)
+                except Exception as e:
+                    logger.warning(f"Failed to convert issue {issue.get('number')}: {e}")
+                    continue
+
+            logger.info(f"Found {len(work_items)} queued work items")
+            return work_items
+
+        except GitHubAPIError:
+            raise
+        except Exception as e:
+            raise GitHubAPIError(f"Failed to fetch queued items: {e}") from e
+
+    def update_item_status(self, item: WorkItem, status: WorkItemStatus) -> WorkItem:
+        """Update the status of a work item in the queue.
+
+        Updates the GitHub issue's labels to reflect the new status.
+        Removes the old status label and adds the new one.
+
+        Args:
+            item: The work item to update.
+            status: The new status to set for the work item.
+
+        Returns:
+            The updated WorkItem with the new status reflected.
+
+        Raises:
+            GitHubAPIError: If the GitHub API request fails.
+            ItemNotFoundError: If the issue cannot be found.
+        """
+        logger.info(f"Updating item {item.id} status to {status}")
+
+        issue_number = int(item.id)
+        new_label = self._get_status_label(status)
+
+        try:
+            # Get current issue to retrieve existing labels
+            issue = self._make_request("GET", f"/repos/{self.repo}/issues/{issue_number}")
+
+            current_labels = [label["name"] for label in issue.get("labels", [])]
+
+            # Remove old status labels and add new one
+            updated_labels = [label for label in current_labels if label not in LABEL_TO_STATUS]
+            updated_labels.append(new_label)
+
+            # Update the issue
+            self._make_request(
+                "PATCH",
+                f"/repos/{self.repo}/issues/{issue_number}",
+                json={"labels": updated_labels},
+            )
+
+            # Return updated work item with deep copy to avoid mutating original
+            updated_item = item.model_copy(deep=True)
+            updated_item.status = status
+
+            # Update metadata with new labels
+            updated_item.metadata["labels"] = updated_labels
+
+            logger.info(f"Successfully updated item {item.id} to status {status}")
+            return updated_item
+
+        except GitHubAPIError as e:
+            if e.status_code == 404:
+                raise ItemNotFoundError(f"Issue {item.id} not found in {self.repo}") from e
+            raise
+        except Exception as e:
+            raise GitHubAPIError(f"Failed to update item status: {e}") from e
+
+
+class GitHubAPIError(Exception):
+    """Exception raised when GitHub API requests fail."""
+
+    def __init__(
+        self,
+        message: str,
+        status_code: int | None = None,
+        response: requests.Response | None = None,
+    ) -> None:
+        """Initialize the GitHub API error.
+
+        Args:
+            message: Error message.
+            status_code: HTTP status code from the response.
+            response: The raw requests Response object.
+        """
+        super().__init__(message)
+        self.status_code = status_code
+        self.response = response
+
+
+class ItemNotFoundError(Exception):
+    """Exception raised when a work item cannot be found in the queue."""
+
+    pass
+
+
+class QueueConnectionError(Exception):
+    """Exception raised when unable to connect to the queue provider."""
+
+    pass
+
+
+class QueueAuthenticationError(Exception):
+    """Exception raised when authentication with the provider fails."""
+
+    pass

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests package."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,1 @@
+"""Configuration file for pytest."""

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests package."""

--- a/tests/unit/test_github_issue_queue.py
+++ b/tests/unit/test_github_issue_queue.py
@@ -1,0 +1,415 @@
+"""Tests for GitHubIssueQueue implementation."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sentinel.models import TaskType, WorkItem, WorkItemStatus
+from sentinel.providers.github import GitHubIssueQueue
+from sentinel.providers.github.issue_queue import (
+    LABEL_TO_STATUS,
+    STATUS_TO_LABEL,
+    GitHubAPIError,
+    ItemNotFoundError,
+)
+
+
+class TestStatusLabelMappings:
+    """Tests for status-label mapping constants."""
+
+    def test_all_statuses_have_label_mappings(self) -> None:
+        """Test that all WorkItemStatus values have corresponding labels."""
+        for status in WorkItemStatus:
+            assert status in STATUS_TO_LABEL, f"Missing label for {status}"
+
+    def test_all_labels_have_status_mappings(self) -> None:
+        """Test that all labels have corresponding statuses."""
+        for status, label in STATUS_TO_LABEL.items():
+            assert label in LABEL_TO_STATUS, f"Missing status for label {label}"
+            assert LABEL_TO_STATUS[label] == status
+
+    def test_label_format(self) -> None:
+        """Test that all labels follow the orchestration: prefix pattern."""
+        for label in STATUS_TO_LABEL.values():
+            assert label.startswith("orchestration:"), f"Label {label} missing prefix"
+
+
+class TestGitHubIssueQueueInit:
+    """Tests for GitHubIssueQueue initialization."""
+
+    def test_init_with_token(self) -> None:
+        """Test initialization with explicit token."""
+        queue = GitHubIssueQueue(repo="owner/repo", token="test-token")
+
+        assert queue.repo == "owner/repo"
+        assert queue.token == "test-token"
+        assert queue.api_base == "https://api.github.com"
+
+    def test_init_with_env_token(self) -> None:
+        """Test initialization with token from environment."""
+        with patch.dict(os.environ, {"GITHUB_TOKEN": "env-token"}, clear=True):
+            queue = GitHubIssueQueue(repo="owner/repo")
+            assert queue.token == "env-token"
+
+    def test_init_with_gh_token_env(self) -> None:
+        """Test initialization with GH_TOKEN from environment."""
+        with patch.dict(os.environ, {"GH_TOKEN": "gh-env-token"}, clear=True):
+            queue = GitHubIssueQueue(repo="owner/repo")
+            assert queue.token == "gh-env-token"
+
+    def test_init_github_token_takes_precedence(self) -> None:
+        """Test that GITHUB_TOKEN takes precedence over GH_TOKEN."""
+        with patch.dict(
+            os.environ,
+            {"GITHUB_TOKEN": "github-token", "GH_TOKEN": "gh-token"},
+            clear=True,
+        ):
+            queue = GitHubIssueQueue(repo="owner/repo")
+            assert queue.token == "github-token"
+
+    def test_init_explicit_token_overrides_env(self) -> None:
+        """Test that explicit token overrides environment."""
+        with patch.dict(os.environ, {"GITHUB_TOKEN": "env-token"}, clear=True):
+            queue = GitHubIssueQueue(repo="owner/repo", token="explicit-token")
+            assert queue.token == "explicit-token"
+
+    def test_init_custom_api_base(self) -> None:
+        """Test initialization with custom API base URL."""
+        queue = GitHubIssueQueue(
+            repo="owner/repo",
+            token="test-token",
+            api_base="https://github.enterprise.com/api/v3",
+        )
+        assert queue.api_base == "https://github.enterprise.com/api/v3"
+
+    def test_init_api_base_trailing_slash_removed(self) -> None:
+        """Test that trailing slash is removed from API base."""
+        queue = GitHubIssueQueue(
+            repo="owner/repo",
+            token="test-token",
+            api_base="https://api.github.com/",
+        )
+        assert queue.api_base == "https://api.github.com"
+
+    def test_init_invalid_repo_format_raises_error(self) -> None:
+        """Test that invalid repo format raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid repo format"):
+            GitHubIssueQueue(repo="invalid-repo", token="test-token")
+
+    def test_init_missing_token_raises_error(self) -> None:
+        """Test that missing token raises ValueError."""
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(ValueError, match="GitHub token is required"):
+                GitHubIssueQueue(repo="owner/repo")
+
+    def test_init_repo_with_multiple_slashes_raises_error(self) -> None:
+        """Test that repo with multiple slashes raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid repo format"):
+            GitHubIssueQueue(repo="owner/repo/extra", token="test-token")
+
+
+class TestGitHubIssueQueueFetchQueuedItems:
+    """Tests for fetch_queued_items method."""
+
+    @pytest.fixture
+    def queue(self) -> GitHubIssueQueue:
+        """Create a GitHubIssueQueue instance for testing."""
+        return GitHubIssueQueue(repo="owner/repo", token="test-token")
+
+    @pytest.fixture
+    def mock_issue_response(self) -> list[dict]:
+        """Create a mock issue response."""
+        return [
+            {
+                "number": 42,
+                "html_url": "https://github.com/owner/repo/issues/42",
+                "body": "Implement feature X",
+                "labels": [
+                    {"name": "orchestration:ready"},
+                    {"name": "enhancement"},
+                ],
+                "node_id": "I_kwDOABC123",
+                "title": "Feature X Implementation",
+                "created_at": "2024-01-01T00:00:00Z",
+                "updated_at": "2024-01-02T00:00:00Z",
+                "user": {"login": "developer"},
+            },
+            {
+                "number": 43,
+                "html_url": "https://github.com/owner/repo/issues/43",
+                "body": "Plan the architecture",
+                "labels": [
+                    {"name": "orchestration:ready"},
+                    {"name": "task-type:plan"},
+                ],
+                "node_id": "I_kwDOABC456",
+                "title": "Architecture Planning",
+                "created_at": "2024-01-01T00:00:00Z",
+                "updated_at": "2024-01-02T00:00:00Z",
+                "user": {"login": "architect"},
+            },
+        ]
+
+    def test_fetch_queued_items_success(
+        self,
+        queue: GitHubIssueQueue,
+        mock_issue_response: list[dict],
+    ) -> None:
+        """Test successful fetch of queued items."""
+        with patch.object(queue, "_make_request", return_value=mock_issue_response):
+            items = queue.fetch_queued_items()
+
+            assert len(items) == 2
+            assert items[0].id == "42"
+            assert items[0].status == WorkItemStatus.QUEUED
+            assert items[0].task_type == TaskType.IMPLEMENT
+            assert items[1].task_type == TaskType.PLAN
+
+    def test_fetch_queued_items_filters_pull_requests(
+        self,
+        queue: GitHubIssueQueue,
+        mock_issue_response: list[dict],
+    ) -> None:
+        """Test that pull requests are filtered out."""
+        mock_issue_response.append(
+            {
+                "number": 44,
+                "html_url": "https://github.com/owner/repo/pull/44",
+                "body": "This is a PR",
+                "labels": [{"name": "orchestration:ready"}],
+                "pull_request": {"url": "https://api.github.com/repos/owner/repo/pulls/44"},
+            }
+        )
+
+        with patch.object(queue, "_make_request", return_value=mock_issue_response):
+            items = queue.fetch_queued_items()
+
+            # Should only have 2 items (PR filtered out)
+            assert len(items) == 2
+            assert all(item.id != "44" for item in items)
+
+    def test_fetch_queued_items_empty_response(self, queue: GitHubIssueQueue) -> None:
+        """Test handling of empty response."""
+        with patch.object(queue, "_make_request", return_value=[]):
+            items = queue.fetch_queued_items()
+            assert items == []
+
+    def test_fetch_queued_items_metadata_populated(
+        self,
+        queue: GitHubIssueQueue,
+        mock_issue_response: list[dict],
+    ) -> None:
+        """Test that metadata is properly populated."""
+        with patch.object(queue, "_make_request", return_value=mock_issue_response[:1]):
+            items = queue.fetch_queued_items()
+
+            assert len(items) == 1
+            assert items[0].metadata["issue_node_id"] == "I_kwDOABC123"
+            assert items[0].metadata["title"] == "Feature X Implementation"
+            assert items[0].metadata["user"] == "developer"
+
+    def test_fetch_queued_items_api_error(self, queue: GitHubIssueQueue) -> None:
+        """Test that API errors are properly raised."""
+        with patch.object(
+            queue,
+            "_make_request",
+            side_effect=GitHubAPIError("API Error", status_code=500),
+        ), pytest.raises(GitHubAPIError):
+            queue.fetch_queued_items()
+
+    def test_fetch_queued_items_correct_params(self, queue: GitHubIssueQueue) -> None:
+        """Test that correct API parameters are used."""
+        mock_request = MagicMock(return_value=[])
+        with patch.object(queue, "_make_request", mock_request):
+            queue.fetch_queued_items()
+
+            call_args = mock_request.call_args
+            assert call_args[0][0] == "GET"
+            assert "/repos/owner/repo/issues" in call_args[0][1]
+            params = call_args[1]["params"]
+            assert params["state"] == "open"
+            assert params["labels"] == "orchestration:ready"
+
+
+class TestGitHubIssueQueueUpdateItemStatus:
+    """Tests for update_item_status method."""
+
+    @pytest.fixture
+    def queue(self) -> GitHubIssueQueue:
+        """Create a GitHubIssueQueue instance for testing."""
+        return GitHubIssueQueue(repo="owner/repo", token="test-token")
+
+    @pytest.fixture
+    def work_item(self) -> WorkItem:
+        """Create a sample WorkItem for testing."""
+        return WorkItem(
+            id="42",
+            source_url="https://github.com/owner/repo/issues/42",
+            context_body="Test item",
+            target_repo_slug="owner/repo",
+            task_type=TaskType.IMPLEMENT,
+            status=WorkItemStatus.QUEUED,
+            metadata={"labels": ["orchestration:ready", "enhancement"]},
+        )
+
+    @pytest.fixture
+    def mock_issue_response(self) -> dict:
+        """Create a mock issue response."""
+        return {
+            "number": 42,
+            "labels": [
+                {"name": "orchestration:ready"},
+                {"name": "enhancement"},
+            ],
+        }
+
+    def test_update_item_status_success(
+        self,
+        queue: GitHubIssueQueue,
+        work_item: WorkItem,
+        mock_issue_response: dict,
+    ) -> None:
+        """Test successful status update."""
+        with patch.object(queue, "_make_request", return_value=mock_issue_response):
+            updated = queue.update_item_status(work_item, WorkItemStatus.IN_PROGRESS)
+
+            assert updated.status == WorkItemStatus.IN_PROGRESS
+            assert STATUS_TO_LABEL[WorkItemStatus.IN_PROGRESS] in updated.metadata["labels"]
+            assert STATUS_TO_LABEL[WorkItemStatus.QUEUED] not in updated.metadata["labels"]
+
+    def test_update_item_status_preserves_original(
+        self,
+        queue: GitHubIssueQueue,
+        work_item: WorkItem,
+        mock_issue_response: dict,
+    ) -> None:
+        """Test that original item is not modified."""
+        original_status = work_item.status
+        original_labels = work_item.metadata["labels"].copy()
+
+        with patch.object(queue, "_make_request", return_value=mock_issue_response):
+            updated = queue.update_item_status(work_item, WorkItemStatus.COMPLETED)
+
+            # Original should be unchanged
+            assert work_item.status == original_status
+            assert work_item.metadata["labels"] == original_labels
+
+            # Updated should have new status
+            assert updated.status == WorkItemStatus.COMPLETED
+
+    def test_update_item_status_not_found(
+        self,
+        queue: GitHubIssueQueue,
+        work_item: WorkItem,
+    ) -> None:
+        """Test handling of item not found error."""
+        with patch.object(
+            queue,
+            "_make_request",
+            side_effect=GitHubAPIError("Not found", status_code=404),
+        ), pytest.raises(ItemNotFoundError):
+            queue.update_item_status(work_item, WorkItemStatus.IN_PROGRESS)
+
+    def test_update_item_status_preserves_non_status_labels(
+        self,
+        queue: GitHubIssueQueue,
+        work_item: WorkItem,
+    ) -> None:
+        """Test that non-status labels are preserved."""
+        mock_response = {
+            "number": 42,
+            "labels": [
+                {"name": "orchestration:ready"},
+                {"name": "enhancement"},
+                {"name": "priority-high"},
+            ],
+        }
+
+        with patch.object(queue, "_make_request", return_value=mock_response):
+            updated = queue.update_item_status(work_item, WorkItemStatus.IN_PROGRESS)
+
+            assert "enhancement" in updated.metadata["labels"]
+            assert "priority-high" in updated.metadata["labels"]
+
+    def test_update_item_status_all_statuses(
+        self,
+        queue: GitHubIssueQueue,
+        work_item: WorkItem,
+        mock_issue_response: dict,
+    ) -> None:
+        """Test updating to all possible statuses."""
+        for status in WorkItemStatus:
+            with patch.object(queue, "_make_request", return_value=mock_issue_response):
+                updated = queue.update_item_status(work_item, status)
+                assert updated.status == status
+
+
+class TestGitHubAPIError:
+    """Tests for GitHubAPIError exception."""
+
+    def test_error_with_message(self) -> None:
+        """Test error with just a message."""
+        error = GitHubAPIError("Something went wrong")
+        assert str(error) == "Something went wrong"
+        assert error.status_code is None
+        assert error.response is None
+
+    def test_error_with_status_code(self) -> None:
+        """Test error with status code."""
+        error = GitHubAPIError("Not found", status_code=404)
+        assert error.status_code == 404
+
+    def test_error_with_response(self) -> None:
+        """Test error with response object."""
+        mock_response = MagicMock()
+        error = GitHubAPIError("Server error", status_code=500, response=mock_response)
+        assert error.response == mock_response
+
+
+class TestMakeRequest:
+    """Tests for _make_request method."""
+
+    @pytest.fixture
+    def queue(self) -> GitHubIssueQueue:
+        """Create a GitHubIssueQueue instance for testing."""
+        return GitHubIssueQueue(repo="owner/repo", token="test-token")
+
+    def test_make_request_success(self, queue: GitHubIssueQueue) -> None:
+        """Test successful API request."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"id": 123}
+
+        with patch("requests.request", return_value=mock_response):
+            result = queue._make_request("GET", "/test")
+
+            assert result == {"id": 123}
+
+    def test_make_request_error_response(self, queue: GitHubIssueQueue) -> None:
+        """Test handling of error response."""
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_response.text = "Not found"
+        mock_response.json.return_value = {}
+
+        with patch("requests.request", return_value=mock_response):
+            with pytest.raises(GitHubAPIError) as exc_info:
+                queue._make_request("GET", "/test")
+
+            assert exc_info.value.status_code == 404
+
+    def test_make_request_includes_headers(self, queue: GitHubIssueQueue) -> None:
+        """Test that request includes proper headers."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {}
+
+        with patch("requests.request") as mock_request:
+            mock_request.return_value = mock_response
+            queue._make_request("GET", "/test")
+
+            headers = mock_request.call_args[1]["headers"]
+            assert "Authorization" in headers
+            assert headers["Authorization"] == "Bearer test-token"
+            assert "Accept" in headers

--- a/tests/unit/test_work_item.py
+++ b/tests/unit/test_work_item.py
@@ -1,0 +1,285 @@
+"""Tests for WorkItem model."""
+
+import pytest
+from pydantic import ValidationError
+
+from sentinel.models import TaskType, WorkItem, WorkItemStatus
+
+
+class TestTaskType:
+    """Tests for TaskType enum."""
+
+    def test_task_type_plan_exists(self) -> None:
+        """Test that PLAN task type exists."""
+        assert TaskType.PLAN == "PLAN"
+
+    def test_task_type_implement_exists(self) -> None:
+        """Test that IMPLEMENT task type exists."""
+        assert TaskType.IMPLEMENT == "IMPLEMENT"
+
+    def test_task_type_values(self) -> None:
+        """Test all TaskType values."""
+        values = {t.value for t in TaskType}
+        assert values == {"PLAN", "IMPLEMENT"}
+
+
+class TestWorkItemStatus:
+    """Tests for WorkItemStatus enum."""
+
+    def test_queued_status(self) -> None:
+        """Test QUEUED status."""
+        assert WorkItemStatus.QUEUED == "QUEUED"
+
+    def test_in_progress_status(self) -> None:
+        """Test IN_PROGRESS status."""
+        assert WorkItemStatus.IN_PROGRESS == "IN_PROGRESS"
+
+    def test_blocked_status(self) -> None:
+        """Test BLOCKED status."""
+        assert WorkItemStatus.BLOCKED == "BLOCKED"
+
+    def test_review_status(self) -> None:
+        """Test REVIEW status."""
+        assert WorkItemStatus.REVIEW == "REVIEW"
+
+    def test_completed_status(self) -> None:
+        """Test COMPLETED status."""
+        assert WorkItemStatus.COMPLETED == "COMPLETED"
+
+    def test_cancelled_status(self) -> None:
+        """Test CANCELLED status."""
+        assert WorkItemStatus.CANCELLED == "CANCELLED"
+
+    def test_all_statuses_defined(self) -> None:
+        """Test all expected statuses are defined."""
+        expected = {
+            "QUEUED",
+            "IN_PROGRESS",
+            "BLOCKED",
+            "REVIEW",
+            "COMPLETED",
+            "CANCELLED",
+        }
+        actual = {s.value for s in WorkItemStatus}
+        assert actual == expected
+
+
+class TestWorkItem:
+    """Tests for WorkItem model."""
+
+    def test_create_work_item_with_required_fields(self) -> None:
+        """Test creating a WorkItem with only required fields."""
+        item = WorkItem(
+            id="42",
+            source_url="https://github.com/owner/repo/issues/42",
+            context_body="Implement feature X",
+            target_repo_slug="owner/repo",
+            task_type=TaskType.IMPLEMENT,
+        )
+
+        assert item.id == "42"
+        assert item.source_url == "https://github.com/owner/repo/issues/42"
+        assert item.context_body == "Implement feature X"
+        assert item.target_repo_slug == "owner/repo"
+        assert item.task_type == TaskType.IMPLEMENT
+        assert item.status == WorkItemStatus.QUEUED  # Default
+        assert item.metadata == {}  # Default
+
+    def test_create_work_item_with_all_fields(self) -> None:
+        """Test creating a WorkItem with all fields."""
+        item = WorkItem(
+            id="123",
+            source_url="https://github.com/owner/repo/issues/123",
+            context_body="Plan the architecture",
+            target_repo_slug="owner/repo",
+            task_type=TaskType.PLAN,
+            status=WorkItemStatus.IN_PROGRESS,
+            metadata={
+                "issue_node_id": "I_kwDOABC123",
+                "labels": ["enhancement"],
+            },
+        )
+
+        assert item.id == "123"
+        assert item.status == WorkItemStatus.IN_PROGRESS
+        assert item.metadata["issue_node_id"] == "I_kwDOABC123"
+        assert item.metadata["labels"] == ["enhancement"]
+
+    def test_work_item_with_integer_id(self) -> None:
+        """Test WorkItem accepts integer ID."""
+        item = WorkItem(
+            id=42,
+            source_url="https://github.com/owner/repo/issues/42",
+            context_body="Test",
+            target_repo_slug="owner/repo",
+            task_type=TaskType.IMPLEMENT,
+        )
+
+        assert item.id == 42
+
+    def test_work_item_default_status_is_queued(self) -> None:
+        """Test that default status is QUEUED."""
+        item = WorkItem(
+            id="1",
+            source_url="https://github.com/owner/repo/issues/1",
+            context_body="Test",
+            target_repo_slug="owner/repo",
+            task_type=TaskType.IMPLEMENT,
+        )
+
+        assert item.status == WorkItemStatus.QUEUED
+
+    def test_work_item_default_metadata_is_empty_dict(self) -> None:
+        """Test that default metadata is an empty dict."""
+        item = WorkItem(
+            id="1",
+            source_url="https://github.com/owner/repo/issues/1",
+            context_body="Test",
+            target_repo_slug="owner/repo",
+            task_type=TaskType.IMPLEMENT,
+        )
+
+        assert item.metadata == {}
+        assert isinstance(item.metadata, dict)
+
+    def test_work_item_missing_required_field_raises_error(self) -> None:
+        """Test that missing required fields raises ValidationError."""
+        with pytest.raises(ValidationError) as exc_info:
+            WorkItem(
+                id="1",
+                # missing source_url
+                context_body="Test",
+                target_repo_slug="owner/repo",
+                task_type=TaskType.IMPLEMENT,
+            )
+
+        errors = exc_info.value.errors()
+        assert any(e["loc"] == ("source_url",) for e in errors)
+
+    def test_work_item_invalid_target_repo_slug_raises_error(self) -> None:
+        """Test that invalid repo slug format raises ValidationError."""
+        with pytest.raises(ValidationError) as exc_info:
+            WorkItem(
+                id="1",
+                source_url="https://github.com/owner/repo/issues/1",
+                context_body="Test",
+                target_repo_slug="invalid-repo-slug",  # Missing /
+                task_type=TaskType.IMPLEMENT,
+            )
+
+        errors = exc_info.value.errors()
+        assert any(e["loc"] == ("target_repo_slug",) for e in errors)
+
+    def test_work_item_accepts_valid_repo_slug(self) -> None:
+        """Test that valid repo slug format is accepted."""
+        item = WorkItem(
+            id="1",
+            source_url="https://github.com/owner/repo/issues/1",
+            context_body="Test",
+            target_repo_slug="owner/repo",
+            task_type=TaskType.IMPLEMENT,
+        )
+
+        assert item.target_repo_slug == "owner/repo"
+
+    def test_work_item_extra_fields_forbidden(self) -> None:
+        """Test that extra fields are forbidden."""
+        with pytest.raises(ValidationError) as exc_info:
+            WorkItem(
+                id="1",
+                source_url="https://github.com/owner/repo/issues/1",
+                context_body="Test",
+                target_repo_slug="owner/repo",
+                task_type=TaskType.IMPLEMENT,
+                extra_field="not allowed",  # type: ignore
+            )
+
+        errors = exc_info.value.errors()
+        assert any(e["loc"] == ("extra_field",) for e in errors)
+
+    def test_work_item_model_copy(self) -> None:
+        """Test that model_copy creates a proper copy."""
+        original = WorkItem(
+            id="1",
+            source_url="https://github.com/owner/repo/issues/1",
+            context_body="Test",
+            target_repo_slug="owner/repo",
+            task_type=TaskType.IMPLEMENT,
+            status=WorkItemStatus.QUEUED,
+        )
+
+        updated = original.model_copy(update={"status": WorkItemStatus.IN_PROGRESS})
+
+        assert original.status == WorkItemStatus.QUEUED
+        assert updated.status == WorkItemStatus.IN_PROGRESS
+
+    def test_work_item_json_serialization(self) -> None:
+        """Test JSON serialization of WorkItem."""
+        item = WorkItem(
+            id="42",
+            source_url="https://github.com/owner/repo/issues/42",
+            context_body="Test content",
+            target_repo_slug="owner/repo",
+            task_type=TaskType.IMPLEMENT,
+            status=WorkItemStatus.QUEUED,
+        )
+
+        json_str = item.model_dump_json()
+        assert '"id":"42"' in json_str or '"id": 42' in json_str
+        assert '"task_type":"IMPLEMENT"' in json_str
+        assert '"status":"QUEUED"' in json_str
+
+    def test_work_item_dict_export(self) -> None:
+        """Test dict export of WorkItem."""
+        item = WorkItem(
+            id="42",
+            source_url="https://github.com/owner/repo/issues/42",
+            context_body="Test content",
+            target_repo_slug="owner/repo",
+            task_type=TaskType.PLAN,
+            status=WorkItemStatus.IN_PROGRESS,
+        )
+
+        data = item.model_dump()
+
+        assert data["id"] == "42"
+        assert data["task_type"] == TaskType.PLAN or data["task_type"] == "PLAN"
+        assert data["status"] == WorkItemStatus.IN_PROGRESS or data["status"] == "IN_PROGRESS"
+
+    def test_work_item_with_complex_metadata(self) -> None:
+        """Test WorkItem with complex metadata."""
+        metadata = {
+            "issue_node_id": "I_kwDOABC123",
+            "labels": ["bug", "priority-high", "area:auth"],
+            "nested": {"key": "value"},
+            "numbers": [1, 2, 3],
+        }
+
+        item = WorkItem(
+            id="42",
+            source_url="https://github.com/owner/repo/issues/42",
+            context_body="Test",
+            target_repo_slug="owner/repo",
+            task_type=TaskType.IMPLEMENT,
+            metadata=metadata,
+        )
+
+        assert item.metadata == metadata
+        assert item.metadata["nested"]["key"] == "value"
+
+    def test_work_item_enum_values_in_json(self) -> None:
+        """Test that enum values are serialized as strings in JSON."""
+        item = WorkItem(
+            id="1",
+            source_url="https://github.com/owner/repo/issues/1",
+            context_body="Test",
+            target_repo_slug="owner/repo",
+            task_type=TaskType.PLAN,
+            status=WorkItemStatus.REVIEW,
+        )
+
+        data = item.model_dump()
+
+        # With use_enum_values=True, enums should be serialized as their values
+        assert data["task_type"] in (TaskType.PLAN, "PLAN")
+        assert data["status"] in (WorkItemStatus.REVIEW, "REVIEW")


### PR DESCRIPTION
## Summary

Implements **Phase 1 Task 1.1 - Standardized Work Item Interface** for the Sentinel MVP as defined in Epic #4.

This PR provides a unified Pydantic-based WorkItem model and abstract IWorkQueue interface to decouple orchestrator logic from specific queue providers (GitHub, Linear, Jira, etc.).

## Changes

### Core Components

| Component | Description |
|-----------|-------------|
| `src/sentinel/models/work_item.py` | WorkItem Pydantic model with TaskType and WorkItemStatus enums |
| `src/sentinel/interfaces/work_queue.py` | IWorkQueue abstract base class for provider-agnostic operations |
| `src/sentinel/providers/github/issue_queue.py` | GitHubIssueQueue implementation using GitHub REST API |

### Features

- **WorkItem Model**: Provider-agnostic representation with flexible metadata field for provider-specific data (e.g., GitHub node_id)
- **TaskType Enum**: PLAN and IMPLEMENT task types
- **WorkItemStatus Enum**: Maps to GitHub labels (QUEUED, IN_PROGRESS, BLOCKED, REVIEW, COMPLETED, CANCELLED)
- **IWorkQueue Interface**: Abstract methods for `fetch_queued_items()` and `update_item_status()`
- **GitHubIssueQueue**: Concrete implementation with:
  - Bidirectional status-to-label mapping
  - Environment variable token support (GITHUB_TOKEN, GH_TOKEN)
  - Custom API base URL support for GitHub Enterprise
  - Proper error handling with custom exceptions

### Project Structure

```
src/sentinel/
├── __init__.py
├── models/
│   ├── __init__.py
│   └── work_item.py
├── interfaces/
│   ├── __init__.py
│   └── work_queue.py
└── providers/
    ├── __init__.py
    └── github/
        ├── __init__.py
        └── issue_queue.py

tests/unit/
├── test_work_item.py (24 tests)
└── test_github_issue_queue.py (30 tests)
```

## Testing

- **54 tests** all passing
- **92% code coverage** (exceeds 80% requirement)

### Test Coverage by Module

| Module | Coverage |
|--------|----------|
| `models/work_item.py` | 100% |
| `interfaces/work_queue.py` | 78% |
| `providers/github/issue_queue.py` | 90% |

## Acceptance Criteria

- [x] `models.py` defines a WorkItem with fields: id, source_url, context_body, target_repo_slug, task_type, status, and metadata
- [x] `interfaces.py` defines `fetch_queued_items()` and `update_item_status()`
- [x] GitHubIssueQueue implementation successfully maps GH REST API calls to these interfaces
- [x] Unit tests pass with >80% coverage for new modules

## Related

- Closes #4 (Epic: Phase 1 — Task 1.1 — Standardized Work Item Interface)